### PR TITLE
Fix sort route for nested resources

### DIFF
--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -51,7 +51,7 @@ module ActiveAdmin
         sort_url = if (( sort_url_block = @options[:sort_url] ))
                      sort_url_block.call(self)
                    else
-                     url_for([:sort, ActiveAdmin.application.default_namespace, @resource_name.pluralize])
+                     url_for(:action => :sort)
                    end
         data_options = {
           "data-sortable-type" => (tree? ? "tree" : "list"),


### PR DESCRIPTION
Fix to prevent `undefined method "sort_admin_(.*)_path"` when resource is nested beneath another. Generate the URL for the current resource's `:sort` action with a simpler call to `url_for(action: :sort)`.
