### PR TITLE
Add lightweight specs using MiniTest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ begin
 rescue LoadError
   puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
 end
+
 begin
   require 'rdoc/task'
 rescue LoadError
@@ -20,8 +21,6 @@ RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 
-
-
-
 Bundler::GemHelper.install_tasks
 
+Dir.glob('lib/tasks/*.rake').each { |r| import r }

--- a/activeadmin-sortable-tree.gemspec
+++ b/activeadmin-sortable-tree.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activeadmin"
 
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "minitest"
 end

--- a/lib/tasks/activeadmin-tree_tasks.rake
+++ b/lib/tasks/activeadmin-tree_tasks.rake
@@ -1,4 +1,8 @@
-# desc "Explaining what the task does"
-# task :activeadmin-tree do
-#   # Task goes here
-# end
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << "spec"
+  t.pattern = "spec/**/*_spec.rb"
+end
+
+task :default => :test

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,8 +1,6 @@
 require "bundler/setup"
 
-require "minitest/spec"
-require "minitest/mock"
-require "minitest/pride"
 require "minitest/autorun"
+require "minitest/pride"
 
 require "arbre"

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,0 +1,8 @@
+require "bundler/setup"
+
+require "minitest/spec"
+require "minitest/mock"
+require "minitest/pride"
+require "minitest/autorun"
+
+require "arbre"

--- a/spec/views/index_as_sortable_spec.rb
+++ b/spec/views/index_as_sortable_spec.rb
@@ -1,0 +1,107 @@
+require "test_helper"
+require "active_admin/component"
+require "active_admin/views/index_as_sortable"
+
+describe ActiveAdmin::Views::IndexAsSortable do
+  let(:described_class) { ActiveAdmin::Views::IndexAsSortable }
+  let(:view) { described_class.new }
+
+  subject { view }
+
+  before do
+    described_class.send(:include, ActiveAdminHelpers)
+    subject.active_admin_config = active_admin_config
+  end
+
+  let(:active_admin_config) do
+    config = MiniTest::Mock.new
+    config.expect(:resource_class, TreeNode)
+    config
+  end
+
+  let(:options) { { roots_method: :roots } }
+
+  it { must_respond_to(:active_admin_config) }
+
+  describe ".index_name" do
+    it "returns sortable" do
+      described_class.index_name.must_equal "sortable"
+    end
+  end
+
+  describe "#tree?" do
+    it "returns true when configured for a tree" do
+      subject.stub :options, { tree: true } do
+        subject.tree?.must_equal true
+      end
+    end
+
+    it "returns false by default" do
+      subject.stub :options, { } do
+        subject.tree?.must_equal false
+      end
+    end
+  end
+
+  describe "#roots_collection" do
+    it "returns nil without the :roots_collection option" do
+      subject.stub :options, {} do
+        subject.roots_collection.must_be_nil
+      end
+    end
+
+    it "returns nodes via defined proc when :roots_collection is set" do
+      subject.stub :options, { roots_collection: proc { current_user_roots } } do
+        subject.roots_collection.must_equal [:current_user_tree_node]
+      end
+    end
+  end
+
+  describe "#default_roots_collection" do
+    it "retrieves nodes via roots_method on the resource_class" do
+      subject.stub :options, { roots_method: :roots } do
+        subject.default_roots_collection.must_equal [:tree_node]
+      end
+    end
+  end
+
+  describe "#roots" do
+    it "retrieves default roots without a roots_collection" do
+      subject.stub :options, { roots_method: :roots } do
+        subject.roots.must_equal [:tree_node]
+      end
+    end
+
+    describe "with roots_collection defined" do
+      it "retrieves roots via roots_collection when defined" do
+        subject.stub :options, { roots_method: :roots, roots_collection: proc { current_user_roots } } do
+          subject.roots.must_equal [:current_user_tree_node]
+        end
+      end
+    end
+  end
+end
+
+module ActiveAdminHelpers
+  attr_accessor :active_admin_config
+
+  def controller
+    FakeController.new
+  end
+
+  def resource_class
+    TreeNode
+  end
+end
+
+class TreeNode
+  def self.roots
+    [:tree_node]
+  end
+end
+
+class FakeController
+  def current_user_roots
+    [:current_user_tree_node]
+  end
+end


### PR DESCRIPTION
These specs are to be a basis for verify existing functionality without the added complexity of building out a full Rails application to perform integration testing. This isn't the best solution, but it does help begin to verify the gem's functionality.

### Running Tests

Ensure the application is bundled `bundle` then run `rake test`.