### PR TITLE
Only display expand/collapse class and disclose span when tree node has children

### DIFF
--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -109,9 +109,11 @@ module ActiveAdmin
               resource_selection_cell(item) if active_admin_config.batch_actions.any?
             end
 
-            span :class => :disclose do
-              span
-            end if options[:collapsible]
+            if item.send(options[:children_method]).order(options[:sorting_attribute]).any?
+              span :class => :disclose do
+                span
+              end if options[:collapsible]
+            end
 
             h3 :class => "cell left" do
               call_method_or_proc_on(item, @label)

--- a/vendor/assets/javascripts/jquery.mjs.nestedSortable.js
+++ b/vendor/assets/javascripts/jquery.mjs.nestedSortable.js
@@ -63,8 +63,10 @@
 					if ($li.children(self.options.listType).length) {
 						$li.addClass(self.options.branchClass);
 						// expand/collapse class only if they have children
-						if (self.options.startCollapsed) $li.addClass(self.options.collapsedClass);
-						else $li.addClass(self.options.expandedClass);
+						if ($li.find('li').length > 0) {
+							if (self.options.startCollapsed) $li.addClass(self.options.collapsedClass);
+							else $li.addClass(self.options.expandedClass);
+						}
 					} else {
 						$li.addClass(self.options.leafClass);
 					}


### PR DESCRIPTION
When a tree node is empty the plus/minus sign is still displayed and so is the mouse hover. This commit removes these items for empty tree nodes.
