### PR TITLE
Add option to disable sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ ActiveAdmin.register Page do
            children_method: :children,
            roots_method: :roots,
            roots_collection: nil,       # proc to specifiy retrieval of roots
-           sortable: true,              # Disable sorting (use only 'tree' functionality)
+           sortable: true,              # Disable sorting (use only 'tree' functionality),
+                                        # Can be either a boolean or a Proc (returning boolean, executed in context of controller)
            collapsible: false,          # show +/- buttons to collapse children
            start_collapsed: false,      # when collapsible, start with all roots collapsed
 end

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ ActiveAdmin.register Page do
            children_method: :children,
            roots_method: :roots,
            roots_collection: nil,       # proc to specifiy retrieval of roots
+           sortable: true,              # Disable sorting (use only 'tree' functionality)
            collapsible: false,          # show +/- buttons to collapse children
            start_collapsed: false,      # when collapsible, start with all roots collapsed
 end

--- a/app/assets/javascripts/active_admin/sortable.js.coffee
+++ b/app/assets/javascripts/active_admin/sortable.js.coffee
@@ -52,6 +52,8 @@ $ ->
       max_levels = 1
       tab_hack = 99999
 
+    cancel_selector = "div.item.nosort" if $this.data('disable-sorting')
+
     $this.nestedSortable
       forcePlaceholderSize: true
       forceHelperSizeType: true
@@ -89,3 +91,4 @@ $ ->
           ActiveAdminSortableEvent.trigger('ajaxDone')
         .fail ->
           ActiveAdminSortableEvent.trigger('ajaxFail')
+      cancel: cancel_selector

--- a/app/assets/stylesheets/active_admin/sortable.css.sass
+++ b/app/assets/stylesheets/active_admin/sortable.css.sass
@@ -50,6 +50,10 @@ body.active_admin
             background-color: $cRowSelected
             cursor: move
 
+          &.nosort
+            cursor: default
+
+
           .cell
             margin: 0
             padding: 10px 12px 8px 12px
@@ -73,7 +77,7 @@ body.active_admin
       li.mjs-nestedSortable-collapsed > div > .disclose > span:before
         content: '+ '
 
-      li.mjs-nestedSortable-expanded > div > .disclose > span:before 
+      li.mjs-nestedSortable-expanded > div > .disclose > span:before
         content: '- '
 
 

--- a/lib/active_admin/sortable/controller_actions.rb
+++ b/lib/active_admin/sortable/controller_actions.rb
@@ -12,7 +12,8 @@ module ActiveAdmin::Sortable
                              :max_levels => 0,
                              :protect_root => false,
                              :collapsible => false, #hides +/- buttons
-                             :start_collapsed => false
+                             :start_collapsed => false,
+                             :sortable => true
 
       # BAD BAD BAD FIXME: don't pollute original class
       @sortable_options = options

--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -93,7 +93,7 @@ module ActiveAdmin
         data_options["data-max-levels"] = options[:max_levels]
         data_options["data-start-collapsed"] = options[:start_collapsed]
         data_options["data-protect-root"] = true if options[:protect_root]
-        data_options["data-disable-sorting"] = true if options[:disable_sorting]
+        data_options["data-disable-sorting"] = true if !options[:sortable]
 
         ol data_options do
           @collection.each do |item|
@@ -103,7 +103,7 @@ module ActiveAdmin
       end
 
       def build_nested_item(item)
-        nosort_class = "nosort" if options[:disable_sorting]
+        nosort_class = "nosort" if !options[:sortable]
         li :id => "#{@resource_name}_#{item.id}" do
 
           div :class => "item " << cycle("odd", "even", :name => "list_class") << " #{nosort_class}" do

--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -93,17 +93,27 @@ module ActiveAdmin
         data_options["data-max-levels"] = options[:max_levels]
         data_options["data-start-collapsed"] = options[:start_collapsed]
         data_options["data-protect-root"] = true if options[:protect_root]
-        data_options["data-disable-sorting"] = true if !options[:sortable]
+
+        sortable = sortable?
+        data_options["data-disable-sorting"] = true if !sortable
 
         ol data_options do
           @collection.each do |item|
-            build_nested_item(item)
+            build_nested_item(item, sortable)
           end
         end
       end
 
-      def build_nested_item(item)
-        nosort_class = "nosort" if !options[:sortable]
+      def sortable?
+        if options[:sortable].is_a? Proc
+          controller.instance_exec(&options[:sortable])
+        else
+          options[:sortable]
+        end
+      end
+
+      def build_nested_item(item, sortable)
+        nosort_class = "nosort" if !sortable
         li :id => "#{@resource_name}_#{item.id}" do
 
           div :class => "item " << cycle("odd", "even", :name => "list_class") << " #{nosort_class}" do
@@ -127,7 +137,7 @@ module ActiveAdmin
 
           ol do
             item.send(options[:children_method]).order(options[:sorting_attribute]).each do |c|
-              build_nested_item(c)
+              build_nested_item(c, sortable)
             end
           end if tree?
         end

--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -93,6 +93,7 @@ module ActiveAdmin
         data_options["data-max-levels"] = options[:max_levels]
         data_options["data-start-collapsed"] = options[:start_collapsed]
         data_options["data-protect-root"] = true if options[:protect_root]
+        data_options["data-disable-sorting"] = true if options[:disable_sorting]
 
         ol data_options do
           @collection.each do |item|
@@ -102,9 +103,10 @@ module ActiveAdmin
       end
 
       def build_nested_item(item)
+        nosort_class = "nosort" if options[:disable_sorting]
         li :id => "#{@resource_name}_#{item.id}" do
 
-          div :class => "item " << cycle("odd", "even", :name => "list_class") do
+          div :class => "item " << cycle("odd", "even", :name => "list_class") << " #{nosort_class}" do
             div :class => "cell left" do
               resource_selection_cell(item) if active_admin_config.batch_actions.any?
             end


### PR DESCRIPTION
Adds option 'sortable' (default: true) that can be used to disable drag-and-drop sorting. A use case for this is when you want the collapsable tree behavior, but do not want to allow sorting.