### PR TITLE
Honor authorization on default actions

### DIFF
--- a/lib/active_admin/views/index_as_sortable.rb
+++ b/lib/active_admin/views/index_as_sortable.rb
@@ -134,13 +134,13 @@ module ActiveAdmin
       def build_actions(resource)
         links = ''.html_safe
         if @default_actions
-          if controller.action_methods.include?('show')
+          if controller.action_methods.include?('show') && authorized?(ActiveAdmin::Auth::READ, resource)
             links << link_to(I18n.t('active_admin.view'), resource_path(resource), :class => "member_link view_link")
           end
-          if controller.action_methods.include?('edit')
+          if controller.action_methods.include?('edit') && authorized?(ActiveAdmin::Auth::UPDATE, resource)
             links << link_to(I18n.t('active_admin.edit'), edit_resource_path(resource), :class => "member_link edit_link")
           end
-          if controller.action_methods.include?('destroy')
+          if controller.action_methods.include?('destroy') && authorized?(ActiveAdmin::Auth::DESTROY, resource)
             links << link_to(I18n.t('active_admin.delete'), resource_path(resource), :method => :delete, :data => {:confirm => I18n.t('active_admin.delete_confirmation')}, :class => "member_link delete_link")
           end
         end


### PR DESCRIPTION
This patch ensures that the default actions use the configured authorization adapter in a manner identical to activeadmin's approach (as of this PR).