### PR TITLE
Improve README for people using acts_as_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ ActiveAdmin.register Page do
 end
 ```
 
+**Note**: If you are using the [acts_as_list](https://github.com/swanandp/acts_as_list) gem to manage a `:position` field (not required, but allows for other nice programmatic manipulation of ordered model lists), you must ensure a zero-based index for your list using the `top_of_list` option:
+
+```ruby
+class Page < ActiveRecord::Base
+  # Make this list act like a zero-indexed array to avoid off-by-one errors in your sorting
+  acts_as_list top_of_list: 0
+end
+```
+
 
 ## Usage (generic ActiveAdmin index)
 


### PR DESCRIPTION
A conflict between the way activeadmin-sortable-tree controllers use `each_with_index`, and the way that `acts_as_list` defaults to `top_of_list=1` can be confusing, especially since `top_of_list` is undocumented, so not obvious what it's default behavior is.