### PR TITLE
Rails5 fix: convert params to Hash before using them

### DIFF
--- a/lib/active_admin/sortable_tree/controller_actions.rb
+++ b/lib/active_admin/sortable_tree/controller_actions.rb
@@ -24,6 +24,10 @@ module ActiveAdmin::SortableTree
       collection_action :sort, :method => :post do
         resource_name = active_admin_config.resource_name.to_s.underscore.parameterize('_')
 
+        # Fix for Rails5, where params return an object instead of hash
+        # (http://eileencodes.com/posts/actioncontroller-parameters-now-returns-an-object-instead-of-a-hash/)
+        params = params.to_unsafe_h if params.respond_to?(:to_unsafe_h)
+
         records = params[resource_name].inject({}) do |res, (resource, parent_resource)|
           res[resource_class.find(resource)] = resource_class.find(parent_resource) rescue nil
           res


### PR DESCRIPTION
Fixes following error which is sometimes returned in rails 5:

```
NoMethodError: undefined method `inject' for #<ActionController::Parameters:0x007f89a2faac70>
Did you mean? inspect
1. File "/socialtravel/releases/20160123175638/vendor/bundle/ruby/2.3.0/gems/active_admin-sortable_tree-0.2.1/lib/active_admin/sortable_tree/controller_actions.rb" line 27 in block in sortable
2. File "/socialtravel/releases/20160123175638/vendor/bundle/ruby/2.3.0/gems/actionpack-5.0.0.beta1/lib/action_controller/metal/basic_implicit_render.rb" line 4 in send_action
...
```