### PR TITLE
Don't assume 'activeadmin' is already loaded

### DIFF
--- a/lib/active_admin/sortable_tree.rb
+++ b/lib/active_admin/sortable_tree.rb
@@ -1,3 +1,5 @@
+require 'activeadmin'
+
 require 'active_admin/sortable_tree/compatibility'
 require 'active_admin/sortable_tree/engine'
 require 'active_admin/sortable_tree/controller_actions'


### PR DESCRIPTION
Since the gem depends on `activeadmin`, it should require it.

Otherwise users have to be careful in the order in which they require their gems.

See also: https://github.com/rubocop-hq/rubocop/issues/8207